### PR TITLE
feat(editor): add record style mapping in Java editor adapter

### DIFF
--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/JavaEditorThemeAdapter.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/JavaEditorThemeAdapter.java
@@ -36,6 +36,7 @@ public final class JavaEditorThemeAdapter extends EclipseThemeAdapter {
 		mapSemanticStyle(preferences, theme, TokenKey.KEYWORD, "semanticHighlighting.restrictedKeywords");
 		mapSemanticStyle(preferences, theme, TokenKey.NUMBER, "semanticHighlighting.number");
 		mapSemanticStyle(preferences, theme, TokenKey.CLASS, "semanticHighlighting.class");
+		mapSemanticStyle(preferences, theme, TokenKey.CLASS, "semanticHighlighting.record");
 		mapSemanticStyle(preferences, theme, TokenKey.ABSTRACT_CLASS, "semanticHighlighting.abstractClass");
 		mapSemanticStyle(preferences, theme, TokenKey.INTERFACE, "semanticHighlighting.interface");
 		mapSemanticStyle(preferences, theme, TokenKey.ENUM, "semanticHighlighting.enum");


### PR DESCRIPTION


### Description of the Change

- map semantic highlighting for java records to `semanticHighlighting.record`

### Checklist

- [x] My code builds successfully with `mvn clean verify`.
- [x] I have tested my changes in a running Eclipse instance.
