### PR TITLE
refactor(theme): rename bundled darcula to jetbrains darcula

### DIFF
--- a/bundles/com.github.eclipsethemes/themes/jetbrains_darcula.xml
+++ b/bundles/com.github.eclipsethemes/themes/jetbrains_darcula.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<colorTheme ect-id="63d6a50b-371f-4211-9025-9bfea76cc850" id="5006" name="Darcula" modified="2024-09-21" author="Eclipse Themes" type="dark">
+<colorTheme ect-id="63d6a50b-371f-4211-9025-9bfea76cc850" id="5006" name="JetBrains Darcula" modified="2024-09-21" author="Eclipse Themes" type="dark">
 
     <!-- CORE EDITOR COLORS -->
     <foreground color="#A9B7C6" />


### PR DESCRIPTION
### Description of the Change

Renamed the bundled "Darcula" theme to "JetBrains Darcula".  
This makes it clear that the theme comes from JetBrains and is not the official Dracula theme.  
No style changes were made, only the name was updated.

### Related Issue

Fixes #9

### Checklist

- [x] I have read the [**CONTRIBUTING.md**](https://github.com/ahatem/eclipse-themes-plugin/blob/main/CONTRIBUTING.md) document.
- [x] My code builds successfully with `mvn clean verify`.
- [x] I have tested my changes in a running Eclipse instance.
