### PR TITLE
fix(preferences): handle imported theme more clearly

### DIFF
--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/preferences/EclipseThemesPreferencePage.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/preferences/EclipseThemesPreferencePage.java
@@ -530,22 +530,23 @@ public class EclipseThemesPreferencePage extends PreferencePage implements IWork
 		}
 
 		try {
-			Optional<Theme> importedTheme = EclipseThemes.instance().getManager().importTheme(selectedFile);
-			if (importedTheme.isEmpty()) {
+			Optional<Theme> importedThemeOpt = EclipseThemes.instance().getManager().importTheme(selectedFile);
+			if (importedThemeOpt.isEmpty()) {
 				showErrorMessage("Import Failed",
 						"Could not import theme - it may conflict with an existing theme or have invalid format.");
 				return;
 			}
-
+			Theme importedTheme = importedThemeOpt.get();
+			
 			// Refresh and select the new theme
 			loadThemes();
 			filterThemes();
-
-			selectedTheme = importedTheme.get();
+			
+			selectedTheme = importedTheme;
 			themeViewer.setSelection(new StructuredSelection(selectedTheme));
 
 			showInfoMessage("Import Successful",
-					"Theme '" + selectedTheme.getName() + "' has been imported successfully.");
+					"Theme '" + importedTheme.getName() + "' has been imported successfully.");
 
 		} catch (Exception e) {
 			EclipseThemes.instance().getLogger().error("Import Error", e);


### PR DESCRIPTION
- extract theme from Optional after check
- use extracted theme for selection and messages

### Description of the Change

Improves theme import logic in preferences.  
The imported theme is now extracted from the Optional after an emptiness check,  
and consistently used for setting selection and displaying success messages.  
This makes the code clearer and avoids confusion when handling imports.

### Related Issue

Fixes #4

### Checklist

- [x] I have read the [**CONTRIBUTING.md**](https://github.com/ahatem/eclipse-themes-plugin/blob/main/CONTRIBUTING.md) document.
- [x] My code builds successfully with `mvn clean verify`.
- [x] I have tested my changes in a running Eclipse instance.
