### PR TITLE
style(themes): adjust kintsugi_dark theme colors and styles

### DIFF
--- a/bundles/com.github.eclipsethemes/themes/kintsugi_dark.xml
+++ b/bundles/com.github.eclipsethemes/themes/kintsugi_dark.xml
@@ -36,15 +36,15 @@
 
     <!-- METHODS & FUNCTIONS -->
     <method color="#dddddd" />
-    <staticMethod color="#dddddd" />
+    <staticMethod color="#dddddd" italic="true"/>
     <abstractMethod color="#dddddd" />
     <inheritedMethod color="#dddddd" />
     <methodDeclaration color="#dddddd" />
 
     <!-- VARIABLES & FIELDS -->
     <field color="#dddddd" />
-    <staticField color="#939799" />
-    <constant color="#939799" />
+    <staticField color="#939799" italic="true" />
+    <constant color="#e5c07b" />
     <localVariable color="#dddddd" />
     <localVariableDeclaration color="#dddddd" />
     <argument color="#dddddd" />


### PR DESCRIPTION
- make static methods italic for better differentiation
- change constant color to a more distinct yellow to improve readability

### Description of the Change

- Added italic styling to `staticMethod` and `staticField` for better visual distinction.
- Updated the `constant` color from `#939799` to `#e5c07b` to improve readability and aesthetic consistency.

### Related Issue

No related issue.

### Checklist

- [x] I have read the [**CONTRIBUTING.md**](https://github.com/ahatem/eclipse-themes-plugin/blob/main/CONTRIBUTING.md) document.
- [x] My code builds successfully with `mvn clean verify`.
- [x] I have tested my changes in a running Eclipse instance.
