### PR TITLE
feat(preferences): add reset plugin defaults button

### DIFF
--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/ThemeManager.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/ThemeManager.java
@@ -142,7 +142,7 @@ public final class ThemeManager {
 		return new ArrayList<>(themes.values());
 	}
 
-	public void applyTheme(IWorkbench workbench, Theme selectedTheme) {
+	public void applyTheme(Theme selectedTheme) {
 		adapters.forEach((adapter, plugin) -> {
 			if (plugin != null) {
 				if (Platform.getBundle(plugin) == null) {

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/ThemeManager.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/ThemeManager.java
@@ -162,6 +162,25 @@ public final class ThemeManager {
 		});
 	}
 
+	public void clearTheme() {
+		adapters.forEach((adapter, plugin) -> {
+			if (plugin != null && Platform.getBundle(plugin) == null) {
+				return;
+			}
+			if (adapter.getPreferencesId() == null && plugin == null) {
+				return;
+			}
+
+			try {
+				String id = adapter.getPreferencesId() == null ? plugin : adapter.getPreferencesId();
+				IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode(id);
+				adapter.clear(preferences);
+			} catch (BackingStoreException e) {
+				EclipseThemes.instance().getLogger().error("Could not clear theme", e);
+			}
+		});
+	}
+
 	public Optional<Theme> importTheme(File file) {
 		File copied = new File(installedThemesDir, file.getName());
 

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/EclipseThemeAdapter.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/EclipseThemeAdapter.java
@@ -22,6 +22,11 @@ public abstract class EclipseThemeAdapter {
 	 */
 	public abstract void apply(Theme theme, IEclipsePreferences preferences) throws BackingStoreException;
 
+	/**
+	 * Clears all theme-related preferences for this adapter.
+	 */
+	public abstract void clear(IEclipsePreferences preferences) throws BackingStoreException;
+
 	// === SEMANTIC STYLE PREFERENCES (using dots) ===
 
 	protected static void putSemanticStyle(IEclipsePreferences preferences, String baseName, Token token) {

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/AntEditorThemeAdapter.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/AntEditorThemeAdapter.java
@@ -25,4 +25,15 @@ public final class AntEditorThemeAdapter extends EclipseThemeAdapter {
 
 		flushPreferences(preferences);
 	}
+
+	@Override
+	public void clear(IEclipsePreferences preferences) throws BackingStoreException {
+		clearLegacyStyle(preferences, "org.eclipse.ant.ui.textColor");
+		clearLegacyStyle(preferences, "org.eclipse.ant.ui.commentsColor");
+		clearLegacyStyle(preferences, "org.eclipse.ant.ui.constantStringsColor");
+		clearLegacyStyle(preferences, "org.eclipse.ant.ui.processingInstructionsColor");
+		clearLegacyStyle(preferences, "org.eclipse.ant.ui.dtdColor");
+		clearLegacyStyle(preferences, "org.eclipse.ant.ui.tagsColor");
+		flushPreferences(preferences);
+	}
 }

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/CppEditorThemeAdapter.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/CppEditorThemeAdapter.java
@@ -64,4 +64,53 @@ public final class CppEditorThemeAdapter extends EclipseThemeAdapter {
 
 		flushPreferences(preferences);
 	}
+
+	@Override
+	public void clear(IEclipsePreferences preferences) throws BackingStoreException {
+		// Legacy style mappings (using underscores)
+		clearLegacyStyle(preferences, "c_default");
+		clearLegacyStyle(preferences, "pp_default");
+		clearLegacyStyle(preferences, "c_single_line_comment");
+		clearLegacyStyle(preferences, "c_multi_line_comment");
+		clearLegacyStyle(preferences, "c_comment_task_tag");
+		clearLegacyStyle(preferences, "c_keyword");
+		clearLegacyStyle(preferences, "c_type");
+		clearLegacyStyle(preferences, "pp_directive");
+		clearLegacyStyle(preferences, "c_numbers");
+		clearLegacyStyle(preferences, "c_string");
+		clearLegacyStyle(preferences, "pp_header");
+		clearLegacyStyle(preferences, "c_braces");
+		clearLegacyStyle(preferences, "c_operators");
+		clearLegacyStyle(preferences, "org.eclipse.cdt.internal.ui.text.doctools.doxygen.single");
+		clearLegacyStyle(preferences, "org.eclipse.cdt.internal.ui.text.doctools.doxygen.multi");
+		clearLegacyStyle(preferences, "org.eclipse.cdt.internal.ui.text.doctools.doxygen.recognizedTag");
+
+		// Semantic style mappings (using dots)
+		clearSemanticStyle(preferences, "semanticHighlighting.class");
+		clearSemanticStyle(preferences, "semanticHighlighting.typedef");
+		clearSemanticStyle(preferences, "semanticHighlighting.enumClass");
+		clearSemanticStyle(preferences, "semanticHighlighting.enum");
+		clearSemanticStyle(preferences, "semanticHighlighting.method");
+		clearSemanticStyle(preferences, "semanticHighlighting.externalSDK");
+		clearSemanticStyle(preferences, "semanticHighlighting.function");
+		clearSemanticStyle(preferences, "semanticHighlighting.staticMethod");
+		clearSemanticStyle(preferences, "semanticHighlighting.methodDeclaration");
+		clearSemanticStyle(preferences, "semanticHighlighting.functionDeclaration");
+		clearSemanticStyle(preferences, "semanticHighlighting.field");
+		clearSemanticStyle(preferences, "semanticHighlighting.globalVariable");
+		clearSemanticStyle(preferences, "semanticHighlighting.staticField");
+		clearSemanticStyle(preferences, "semanticHighlighting.enumerator");
+		clearSemanticStyle(preferences, "semanticHighlighting.localVariable");
+		clearSemanticStyle(preferences, "semanticHighlighting.localVariableDeclaration");
+		clearSemanticStyle(preferences, "semanticHighlighting.parameterVariable");
+		clearSemanticStyle(preferences, "semanticHighlighting.templateParameter");
+		clearSemanticStyle(preferences, "semanticHighlighting.macroSubstitution");
+		clearSemanticStyle(preferences, "semanticHighlighting.macroDefinition");
+		clearSemanticStyle(preferences, "semanticHighlighting.namespace");
+
+		// Special case - direct color mapping for matching brackets
+		preferences.remove("matchingBracketsColor");
+
+		flushPreferences(preferences);
+	}
 }

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/GenericEditorThemeAdapter.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/GenericEditorThemeAdapter.java
@@ -20,4 +20,10 @@ public final class GenericEditorThemeAdapter extends EclipseThemeAdapter {
 
 		flushPreferences(preferences);
 	}
+
+	@Override
+	public void clear(IEclipsePreferences preferences) throws BackingStoreException {
+		preferences.remove("matchingBracketsColor");
+		flushPreferences(preferences);
+	}
 }

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/JavaEditorThemeAdapter.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/JavaEditorThemeAdapter.java
@@ -67,7 +67,58 @@ public final class JavaEditorThemeAdapter extends EclipseThemeAdapter {
 		putColor(preferences, "matchingBracketsColor", theme.get(TokenKey.MATCHING_BRACKET));
 
 		flushPreferences(preferences);
+	}
 
+	@Override
+	public void clear(IEclipsePreferences preferences) throws BackingStoreException {
+		// Legacy style mappings (using underscores)
+		clearLegacyStyle(preferences, "java_default");
+		clearLegacyStyle(preferences, "java_single_line_comment");
+		clearLegacyStyle(preferences, "java_multi_line_comment");
+		clearLegacyStyle(preferences, "java_comment_task_tag");
+		clearLegacyStyle(preferences, "java_keyword");
+		clearLegacyStyle(preferences, "java_keyword_return");
+		clearLegacyStyle(preferences, "java_number");
+		clearLegacyStyle(preferences, "java_string");
+		clearLegacyStyle(preferences, "java_bracket");
+		clearLegacyStyle(preferences, "java_operator");
+		clearLegacyStyle(preferences, "java_doc_default");
+		clearLegacyStyle(preferences, "java_doc_keyword");
+		clearLegacyStyle(preferences, "java_doc_link");
+		clearLegacyStyle(preferences, "java_doc_tag");
+
+		// Semantic style mappings (using dots)
+		clearSemanticStyle(preferences, "semanticHighlighting.restrictedKeywords");
+		clearSemanticStyle(preferences, "semanticHighlighting.number");
+		clearSemanticStyle(preferences, "semanticHighlighting.class");
+		clearSemanticStyle(preferences, "semanticHighlighting.record");
+		clearSemanticStyle(preferences, "semanticHighlighting.abstractClass");
+		clearSemanticStyle(preferences, "semanticHighlighting.interface");
+		clearSemanticStyle(preferences, "semanticHighlighting.enum");
+		clearSemanticStyle(preferences, "semanticHighlighting.method");
+		clearSemanticStyle(preferences, "semanticHighlighting.staticMethodInvocation");
+		clearSemanticStyle(preferences, "semanticHighlighting.abstractMethodInvocation");
+		clearSemanticStyle(preferences, "semanticHighlighting.methodDeclarationName");
+		clearSemanticStyle(preferences, "semanticHighlighting.field");
+		clearSemanticStyle(preferences, "semanticHighlighting.staticField");
+		clearSemanticStyle(preferences, "semanticHighlighting.staticFinalField");
+		clearSemanticStyle(preferences, "semanticHighlighting.localVariable");
+		clearSemanticStyle(preferences, "semanticHighlighting.localVariableDeclaration");
+		clearSemanticStyle(preferences, "semanticHighlighting.parameterVariable");
+		clearSemanticStyle(preferences, "semanticHighlighting.annotation");
+		clearSemanticStyle(preferences, "semanticHighlighting.annotationElementReference");
+		clearSemanticStyle(preferences, "semanticHighlighting.typeParameter");
+
+		// Optional semantic style mappings
+		clearSemanticStyle(preferences, "semanticHighlighting.inheritedMethodInvocation");
+		clearSemanticStyle(preferences, "semanticHighlighting.inheritedField");
+		clearSemanticStyle(preferences, "semanticHighlighting.typeArgument");
+		clearSemanticStyle(preferences, "semanticHighlighting.deprecatedMember");
+
+		// Special case - direct color mapping for matching brackets
+		preferences.remove("matchingBracketsColor");
+
+		flushPreferences(preferences);
 	}
 
 }

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/PluginEditorThemeAdapter.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/PluginEditorThemeAdapter.java
@@ -29,4 +29,21 @@ public final class PluginEditorThemeAdapter extends EclipseThemeAdapter {
 
 		flushPreferences(preferences);
 	}
+
+	@Override
+	public void clear(IEclipsePreferences preferences) throws BackingStoreException {
+		clearLegacyStyle(preferences, "editor.color.default");
+		clearLegacyStyle(preferences, "editor.color.header_assignment");
+		clearLegacyStyle(preferences, "editor.color.xml_comment");
+		clearLegacyStyle(preferences, "editor.color.string");
+		clearLegacyStyle(preferences, "editor.color.externalized_string");
+		clearLegacyStyle(preferences, "editor.color.header_value");
+		clearLegacyStyle(preferences, "editor.color.instr");
+		clearLegacyStyle(preferences, "editor.color.tag");
+		clearLegacyStyle(preferences, "editor.color.header_attributes");
+		clearLegacyStyle(preferences, "editor.color.header_osgi");
+
+		flushPreferences(preferences);
+	}
+
 }

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/TextEditorThemeAdapter.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/editor/TextEditorThemeAdapter.java
@@ -94,4 +94,48 @@ public class TextEditorThemeAdapter extends EclipseThemeAdapter {
 		return new Token(null, color, null);
 	}
 
+	@Override
+	public void clear(IEclipsePreferences preferences) throws BackingStoreException {
+		// System color defaults
+		preferences.remove("AbstractTextEditor.Color.Background.SystemDefault");
+		preferences.remove("AbstractTextEditor.Color.Foreground.SystemDefault");
+		preferences.remove("AbstractTextEditor.Color.SelectionBackground.SystemDefault");
+		preferences.remove("AbstractTextEditor.Color.SelectionForeground.SystemDefault");
+
+		// Basic editor colors
+		preferences.remove("AbstractTextEditor.Color.Background");
+		preferences.remove("AbstractTextEditor.Color.Foreground");
+		preferences.remove("AbstractTextEditor.Color.FindScope");
+		preferences.remove("AbstractTextEditor.Color.SelectionBackground");
+		preferences.remove("AbstractTextEditor.Color.SelectionForeground");
+
+		// Editor UI elements
+		preferences.remove("currentLineColor");
+		preferences.remove("lineNumberColor");
+		preferences.remove("printMarginColor");
+
+		// Occurrence highlighting
+		preferences.remove("occurrenceIndicationColor");
+		preferences.remove("LSP4EReadOccurrenceIndicationColor");
+		preferences.remove("org.eclipse.cdt.ui.occurrenceIndicationColor");
+		preferences.remove("writeOccurrenceIndicationColor");
+		preferences.remove("LSP4EWriteOccurrenceIndicationColor");
+		preferences.remove("org.eclipse.cdt.ui.writeOccurrenceIndicationColor");
+		preferences.remove("TextOccurrenceIndicationColor");
+		preferences.remove("LSP4ETextOccurrenceIndicationColor");
+
+		// Search and debug
+		preferences.remove("searchResultIndicationColor");
+		preferences.remove("filteredSearchResultIndicationColor");
+		preferences.remove("currentIPIndication");
+		preferences.remove("secondaryIPIndication");
+
+		// Version control annotations
+		preferences.remove("additionIndicationColor");
+		preferences.remove("changeIndicationColor");
+		preferences.remove("deletionIndicationColor");
+
+		flushPreferences(preferences);
+	}
+
 }

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/ui/DebugConsoleThemeAdapter.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/adapters/ui/DebugConsoleThemeAdapter.java
@@ -22,4 +22,13 @@ public final class DebugConsoleThemeAdapter extends EclipseThemeAdapter {
 
 		flushPreferences(preferences);
 	}
+
+	@Override
+	public void clear(IEclipsePreferences preferences) throws BackingStoreException {
+		preferences.remove("org.eclipse.debug.ui.consoleBackground");
+		preferences.remove("org.eclipse.debug.ui.outColor");
+		preferences.remove("org.eclipse.debug.ui.errorColor");
+
+		flushPreferences(preferences);
+	}
 }

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/preferences/EclipseThemesPreferencePage.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/preferences/EclipseThemesPreferencePage.java
@@ -247,7 +247,7 @@ public class EclipseThemesPreferencePage extends PreferencePage implements IWork
 		removeButton.setToolTipText("Remove the selected custom theme");
 		removeButton.setEnabled(false);
 		setButtonWidth(removeButton, 120);
-		
+
 		// Reset to default button
 		resetPluginDefaultsButton = new Button(buttonArea, SWT.PUSH);
 		resetPluginDefaultsButton.setText("Reset Plugin Defaults");
@@ -420,8 +420,7 @@ public class EclipseThemesPreferencePage extends PreferencePage implements IWork
 				removeSelectedTheme();
 			}
 		});
-		
-		
+
 		resetPluginDefaultsButton.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
@@ -730,7 +729,7 @@ public class EclipseThemesPreferencePage extends PreferencePage implements IWork
 
 	@Override
 	protected void performDefaults() {
-		resetToDefault();
+		EclipseThemes.instance().getManager().clearTheme();
 		super.performDefaults();
 	}
 }

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/preferences/EclipseThemesPreferencePage.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/preferences/EclipseThemesPreferencePage.java
@@ -57,6 +57,7 @@ public class EclipseThemesPreferencePage extends PreferencePage implements IWork
 	private Link downloadMoreLink;
 	private Button importButton;
 	private Button removeButton;
+	private Button resetPluginDefaultsButton;
 	private Button previewToggleButton;
 
 	// Data
@@ -246,6 +247,12 @@ public class EclipseThemesPreferencePage extends PreferencePage implements IWork
 		removeButton.setToolTipText("Remove the selected custom theme");
 		removeButton.setEnabled(false);
 		setButtonWidth(removeButton, 120);
+		
+		// Reset to default button
+		resetPluginDefaultsButton = new Button(buttonArea, SWT.PUSH);
+		resetPluginDefaultsButton.setText("Reset Plugin Defaults");
+		resetPluginDefaultsButton.setToolTipText("Reset plugin settings to default values");
+		setButtonWidth(removeButton, 120);
 	}
 
 	private void setButtonWidth(Button button, int width) {
@@ -411,6 +418,14 @@ public class EclipseThemesPreferencePage extends PreferencePage implements IWork
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				removeSelectedTheme();
+			}
+		});
+		
+		
+		resetPluginDefaultsButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				resetToDefault();
 			}
 		});
 	}

--- a/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/preferences/EclipseThemesPreferencePage.java
+++ b/bundles/com.github.eclipsethemes/src/com/github/eclipsethemes/eclipse/preferences/EclipseThemesPreferencePage.java
@@ -513,7 +513,7 @@ public class EclipseThemesPreferencePage extends PreferencePage implements IWork
 
 		try {
 			getPreferenceStore().setValue(PreferenceKeys.ACTIVE_THEME_ID, selectedTheme.getId());
-			EclipseThemes.instance().getManager().applyTheme(workbench, selectedTheme);
+			EclipseThemes.instance().getManager().applyTheme(selectedTheme);
 
 			currentTheme = selectedTheme;
 			updateButtonStates();
@@ -628,7 +628,7 @@ public class EclipseThemesPreferencePage extends PreferencePage implements IWork
 
 			// Apply the default theme
 			if (defaultTheme != null) {
-				EclipseThemes.instance().getManager().applyTheme(workbench, defaultTheme);
+				EclipseThemes.instance().getManager().applyTheme(defaultTheme);
 				currentTheme = defaultTheme;
 			}
 
@@ -654,7 +654,7 @@ public class EclipseThemesPreferencePage extends PreferencePage implements IWork
 		Theme defaultTheme = getDefaultThemeForCurrentMode();
 
 		if (defaultTheme != null) {
-			EclipseThemes.instance().getManager().applyTheme(workbench, defaultTheme);
+			EclipseThemes.instance().getManager().applyTheme(defaultTheme);
 			currentTheme = defaultTheme;
 			getPreferenceStore().setValue(PreferenceKeys.ACTIVE_THEME_ID, defaultTheme.getId());
 		}


### PR DESCRIPTION
### Description of the Change

Separates resetting Eclipse editors from resetting the plugin state.

- `performDefaults()` now clears plugin-applied theme preferences **and restores all editors to their Eclipse default settings**.
- Adds a **“Reset Plugin Defaults”** button that restores the plugin state:
  - Re-applies the plugin's default theme for the current Eclipse appearance mode (using the existing `resetToDefault()` function).
  - Deletes all imported themes.
  - Updates the preference store and UI to reflect the plugin default.
- Ensures plugin resets do not affect Eclipse defaults, and Eclipse resets do not affect plugin default state.

### Related Issue

None currently, new feature request.

### Checklist

- [x] I have read the [**CONTRIBUTING.md**](https://github.com/ahatem/eclipse-themes-plugin/blob/main/CONTRIBUTING.md) document.
- [x] My code builds successfully with `mvn clean verify`.
- [x] I have tested my changes in a running Eclipse instance.
